### PR TITLE
Relax megaparsec's version bound

### DIFF
--- a/parsers-megaparsec.cabal
+++ b/parsers-megaparsec.cabal
@@ -29,7 +29,7 @@ library
   exposed-modules:     Text.Megaparsec.Parsers
   build-depends:       base >=4.7 && <5
                      , fail >=4.7 && <5
-                     , megaparsec >= 6 && < 8.1
+                     , megaparsec >= 6 && < 9.1
                      , parsers ==0.12.*
                      , mtl >=2.2 && <2.3
                      , semigroups >=0.9 && <0.20


### PR DESCRIPTION
To support megaparsec 9.0.x.